### PR TITLE
Updated SentryPlugin.ts to replace deprecated jovo.getUserId()

### DIFF
--- a/src/SentryPlugin.ts
+++ b/src/SentryPlugin.ts
@@ -42,7 +42,7 @@ export class SentryPlugin implements Plugin {
         const extras = this.getExtras(jovo);
 
         configureScope((scope: Scope) => {
-            scope.setUser({ id: jovo.getUserId() });
+            scope.setUser({ id: jovo.$user.getId() });
             scope.setTag('platform', jovo.getPlatformType());
             scope.setTag('locale', jovo.getLocale() || '');
             scope.setExtras(extras);


### PR DESCRIPTION
Updated SentryPlugin.ts to replace deprecated jovo.getUserId()

jovo.getUserId() has been deprecated. You now should use jovo.$user.getId()