### PR TITLE
chore: update sentry version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jovo-community-plugin-sentry",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -529,89 +529,77 @@
         "chalk": "^3.0.0"
       }
     },
-    "@sentry/apm": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.4.tgz",
-      "integrity": "sha512-gcW225Jls1ShyBXMWN6zZyuVJwBOIQ63sI+URI2NSFsdpBpdpZ8yennIm+oMlSfb25Nzt9SId7TRSjPhlSbTZQ==",
-      "requires": {
-        "@sentry/browser": "5.15.4",
-        "@sentry/hub": "5.15.4",
-        "@sentry/minimal": "5.15.4",
-        "@sentry/types": "5.15.4",
-        "@sentry/utils": "5.15.4",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/browser": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.4.tgz",
-      "integrity": "sha512-l/auT1HtZM3KxjCGQHYO/K51ygnlcuOrM+7Ga8gUUbU9ZXDYw6jRi0+Af9aqXKmdDw1naNxr7OCSy6NBrLWVZw==",
-      "requires": {
-        "@sentry/core": "5.15.4",
-        "@sentry/types": "5.15.4",
-        "@sentry/utils": "5.15.4",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sentry/core": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.4.tgz",
-      "integrity": "sha512-9KP4NM4SqfV5NixpvAymC7Nvp36Zj4dU2fowmxiq7OIbzTxGXDhwuN/t0Uh8xiqlkpkQqSECZ1OjSFXrBldetQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.8.0.tgz",
+      "integrity": "sha512-vJzWt/znEB+JqVwtwfjkRrAYRN+ep+l070Ti8GhJnvwU4IDtVlV3T/jVNrj6rl6UChcczaJQMxVxtG5x0crlAA==",
       "requires": {
-        "@sentry/hub": "5.15.4",
-        "@sentry/minimal": "5.15.4",
-        "@sentry/types": "5.15.4",
-        "@sentry/utils": "5.15.4",
+        "@sentry/hub": "6.8.0",
+        "@sentry/minimal": "6.8.0",
+        "@sentry/types": "6.8.0",
+        "@sentry/utils": "6.8.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.4.tgz",
-      "integrity": "sha512-1XJ1SVqadkbUT4zLS0TVIVl99si7oHizLmghR8LMFl5wOkGEgehHSoOydQkIAX2C7sJmaF5TZ47ORBHgkqclUg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.8.0.tgz",
+      "integrity": "sha512-hFrI2Ss1fTov7CH64FJpigqRxH7YvSnGeqxT9Jc1BL7nzW/vgCK+Oh2mOZbosTcrzoDv+lE8ViOnSN3w/fo+rg==",
       "requires": {
-        "@sentry/types": "5.15.4",
-        "@sentry/utils": "5.15.4",
+        "@sentry/types": "6.8.0",
+        "@sentry/utils": "6.8.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.4.tgz",
-      "integrity": "sha512-GL4GZ3drS9ge+wmxkHBAMEwulaE7DMvAEfKQPDAjg2p3MfcCMhAYfuY4jJByAC9rg9OwBGGehz7UmhWMFjE0tw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.8.0.tgz",
+      "integrity": "sha512-MRxUKXiiYwKjp8mOQMpTpEuIby1Jh3zRTU0cmGZtfsZ38BC1JOle8xlwC4FdtOH+VvjSYnPBMya5lgNHNPUJDQ==",
       "requires": {
-        "@sentry/hub": "5.15.4",
-        "@sentry/types": "5.15.4",
+        "@sentry/hub": "6.8.0",
+        "@sentry/types": "6.8.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.4.tgz",
-      "integrity": "sha512-OfdhNEvOJZ55ZkCUcVgctjaZkOw7rmLzO5VyDTSgevA4uLsPaTNXSAeK2GSQBXc5J0KdRpNz4sSIyuxOS4Z7Vg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.8.0.tgz",
+      "integrity": "sha512-DPUtDd1rRbDJys+aZdQTScKy2Xxo4m8iSQPxzfwFROsLmzE7XhDoriDwM+l1BpiZYIhxUU2TLxDyVzmdc/TMAw==",
       "requires": {
-        "@sentry/apm": "5.15.4",
-        "@sentry/core": "5.15.4",
-        "@sentry/hub": "5.15.4",
-        "@sentry/types": "5.15.4",
-        "@sentry/utils": "5.15.4",
-        "cookie": "^0.3.1",
-        "https-proxy-agent": "^4.0.0",
+        "@sentry/core": "6.8.0",
+        "@sentry/hub": "6.8.0",
+        "@sentry/tracing": "6.8.0",
+        "@sentry/types": "6.8.0",
+        "@sentry/utils": "6.8.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
       }
     },
+    "@sentry/tracing": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.8.0.tgz",
+      "integrity": "sha512-3gDkQnmOuOjHz5rY7BOatLEUksANU3efR8wuBa2ujsPQvoLSLFuyZpRjPPsxuUHQOqAYIbSNAoDloXECvQeHjw==",
+      "requires": {
+        "@sentry/hub": "6.8.0",
+        "@sentry/minimal": "6.8.0",
+        "@sentry/types": "6.8.0",
+        "@sentry/utils": "6.8.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sentry/types": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.4.tgz",
-      "integrity": "sha512-quPHPpeAuwID48HLPmqBiyXE3xEiZLZ5D3CEbU3c3YuvvAg8qmfOOTI6z4Z3Eedi7flvYpnx3n7N3dXIEz30Eg=="
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.8.0.tgz",
+      "integrity": "sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA=="
     },
     "@sentry/utils": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.4.tgz",
-      "integrity": "sha512-lO8SLBjrUDGADl0LOkd55R5oL510d/1SaI08/IBHZCxCUwI4TiYo5EPECq8mrj3XGfgCyq9osw33bymRlIDuSQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.8.0.tgz",
+      "integrity": "sha512-OYlI2JNrcWKMdvYbWNdQwR4QBVv2V0y5wK0U6f53nArv6RsyO5TzwRu5rMVSIZofUUqjoE5hl27jqnR+vpUrsA==",
       "requires": {
-        "@sentry/types": "5.15.4",
+        "@sentry/types": "6.8.0",
         "tslib": "^1.9.3"
       }
     },
@@ -780,9 +768,12 @@
       "dev": true
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.0",
@@ -1291,9 +1282,9 @@
       }
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -2076,11 +2067,11 @@
       }
     },
     "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
       "requires": {
-        "agent-base": "5",
+        "agent-base": "6",
         "debug": "4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jovo-community-plugin-sentry",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A Jovo Framework plugin for Sentry",
   "main": "dist/src/index",
   "types": "dist/src/index.d.ts",
@@ -22,7 +22,8 @@
     "url": "https://github.com/jovo-community/jovo-community-plugin-sentry/issues"
   },
   "dependencies": {
-    "@sentry/node": "^5.15.4",
+    "@sentry/node": "^6.8.0",
+    "@sentry/types": "^6.8.0",
     "husky": "^4.2.3",
     "jovo-core": "^3.0.11"
   },

--- a/src/Sentry.ts
+++ b/src/Sentry.ts
@@ -1,5 +1,6 @@
 import * as SentryClient from '@sentry/node';
 import { Jovo } from 'jovo-core';
+import type { Extras } from '@sentry/types';
 
 export class Sentry {
     jovo: Jovo;
@@ -45,8 +46,8 @@ export class Sentry {
         SentryClient.captureException(error);
     }
 
-    getExtras(): object {
-        let extras: any = {};
+    getExtras(): Extras {
+        let extras: Extras = {};
 
         if (this.jovo) {
             const request = this.jovo.$request?.toJSON();


### PR DESCRIPTION
I updated `@sentry/node` to the latest version and changed the `getExtras` method to return the `Extras` type defined in `@sentry/types`